### PR TITLE
composer.json: Allow PHP 8 and update other dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,30 @@
 version: 2
 jobs:
-  build:
+  build_php7.0:
     docker:
       - image: circleci/php:7.0-apache-stretch-browsers
     steps:
       - checkout
-      - run: composer install
-      - run: composer test
+      - run: COMPOSER=composer-php7.json composer install
+      - run: COMPOSER=composer-php7.json composer test
+  build_php8.0:
+    docker:
+      - image: circleci/php:8.0
+    steps:
+      - checkout
+      - run: COMPOSER=composer.json composer install
+      - run: COMPOSER=composer.json composer test
+  build_php7.4:
+    docker:
+      - image: circleci/php:7.4.6
+    steps:
+      - checkout
+      - run: COMPOSER=composer.json composer install
+      - run: COMPOSER=composer.json composer test
+workflows:
+  version: 2
+  build_php_versions:
+    jobs:
+      - build_php7.0
+      - build_php7.4
+      - build_php8.0

--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ vendor/bin/phpcs -s src/MyProject/MyClass.php
 
 - [VariableAnalysis](https://github.com/sirbrillig/phpcs-variable-analysis): Find undefined and unused variables.
 - [ImportDetection](https://github.com/sirbrillig/phpcs-import-detection): A set of phpcs sniffs to look for unused or unimported symbols.
+

--- a/composer-php7.json
+++ b/composer-php7.json
@@ -1,0 +1,32 @@
+{
+    "name": "sirbrillig/phpcs-no-get-current-user",
+    "description": "A phpcs sniff to disallow get_current_user.",
+    "type": "phpcodesniffer-standard",
+    "license": "BSD-2-Clause",
+    "authors": [
+        {
+            "name": "Payton Swick",
+            "email": "payton@foolord.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "NoGetCurrentUser\\": "NoGetCurrentUser/"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "scripts": {
+        "test": "./vendor/bin/phpunit"
+    },
+    "require" : {
+        "php" : "^7.0"
+    },
+    "require-dev": {
+        "sirbrillig/phpcs-variable-analysis": "^2.4.0",
+        "sirbrillig/phpcs-import-detection": "^1.1.3",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "phpunit/phpunit": "^6.4",
+        "squizlabs/php_codesniffer": "^3.5.8"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,13 @@
         "test": "./vendor/bin/phpunit"
     },
     "require" : {
-        "php" : "^7.0"
+        "php" : "^7.0 || ^8.0"
     },
     "require-dev": {
         "sirbrillig/phpcs-variable-analysis": "^2.4.0",
         "sirbrillig/phpcs-import-detection": "^1.1.3",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-        "phpunit/phpunit": "^6.4",
-        "limedeck/phpunit-detailed-printer": "^3.1",
-        "squizlabs/php_codesniffer": "3.3.0"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+        "phpunit/phpunit": "^9.0",
+        "squizlabs/php_codesniffer": "^3.5.8"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,5 @@
 <phpunit
 	bootstrap="tests/bootstrap.php"
-	printerClass="LimeDeck\Testing\Printer"
 	>
 	<testsuites>
 		<testsuite>


### PR DESCRIPTION
- PHP ^7.0 -> ^7.0 || ^8.0
- Update phpunit from ^6.4 -> ^9.0
- Remove limedeck/phpunit-detailed-printer
- dealerdirect/phpcodesniffer-composer-installer ^0.4.4 -> ^0.7.1
- squizlabs/php_codesniffer 3.3.0 -> ^3.5.8

Cribbed from
https://github.com/sirbrillig/phpcs-import-detection/commit/bd2b114f9c3fb31bd44c4dd943b1e12be4873a30
.
Untested.
Fixes #1 